### PR TITLE
Fix typo "Enums:getEnums() -> Enums:GetEnums()"

### DIFF
--- a/server/rbx/datatypes.json
+++ b/server/rbx/datatypes.json
@@ -3289,7 +3289,7 @@
             "Members": [
                 {
                     "MemberType": "Function",
-                    "Name": "getEnums",
+                    "Name": "GetEnums",
                     "Parameters": [
                         {
                             "Name": "self",


### PR DESCRIPTION
Minor typo in the manual definition for Enums:GetEnums() incorrectly assumes the existence of a camelCase version.
This was likely overlooked due to GetEnums rarely ever being used.