### PR TITLE
Add vector to type()

### DIFF
--- a/server/libs/@lua/basic.lni
+++ b/server/libs/@lua/basic.lni
@@ -468,6 +468,9 @@ name = 'type'
 enum = '"thread"'
 ``````````
 name = 'type'
+enum = '"vector"'
+``````````
+name = 'type'
 enum = '"userdata"'
 
 ["_VERSION Luau"]

--- a/server/script/robloxlibs.lua
+++ b/server/script/robloxlibs.lua
@@ -86,6 +86,10 @@ local function generateTestez(globals)
                 },
                 [8] = {
                     name = "typeName",
+                    enum = '"vector"'
+                },
+                [9] = {
+                    name = "typeName",
                     enum = '"userdata"'
                 }
             },


### PR DESCRIPTION
Added vector to type()'s returns

Roblox is adding Vector3s as a primitive meaning that type() no longer considers it a UserData (read about it here: https://devforum.roblox.com/t/native-luau-vector3-beta/1180548)

well, Vector3 returning vector in type() only affects types returns so I only had to change the basic.lni and one of the TestEz expectations to account for this change.

https://devforum.roblox.com/t/behavior-change-type-will-start-returning-vector-for-vector3/1217482

Heres a visual representation:

![image](https://user-images.githubusercontent.com/68239467/117728859-ebfe4680-b1e1-11eb-8ffd-2732dc284f9b.png)