### PR TITLE
Added .vscodeignore for production

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,6 @@
+.vscode/**
+**/*.ts
+**/*.map
+**/tsconfig.json
+server/log
+.gitignore


### PR DESCRIPTION
This PR adds in a ignore list to remove development scripts and other un-needed stuff when compiling for the published extension.

This includes:
* .vscode folder settings
* All Typescript scripts and .tsconfig.json files as they are development tools and are not needed after compiling. 
* .maps as they are for debugging and are not used in the production
* Empty out server's log. In a fresh install of the extension, some logs were included.

![image](https://user-images.githubusercontent.com/14226603/120218770-3898d880-c208-11eb-855f-0274ee163f95.png)
