### PR TITLE
Reworking of the logging system

### DIFF
--- a/package.json
+++ b/package.json
@@ -568,6 +568,11 @@
 					"markdownDescription": "%config.zzzzzz.cat%",
 					"scope": "resource",
 					"type": "boolean"
+				},
+				"Lua.logging.showDebugMessages": {
+					"default": false,
+					"markdownDescription": "%config.logging.showDebugMessages%",
+					"type": "boolean"
 				}
 			},
 			"title": "Lua",

--- a/package.nls.json
+++ b/package.nls.json
@@ -45,5 +45,6 @@
     "config.workspace.maxPreload": "Max preloaded files.",
     "config.workspace.preloadFileSize": "Skip files larger than this value (KB) when preloading.",
     "config.workspace.useGitIgnore": "Ignore files list in `.gitignore` .",
-    "config.zzzzzz.cat": "DONT TOUCH ME, LET ME SLEEP >_<"
+    "config.zzzzzz.cat": "DONT TOUCH ME, LET ME SLEEP >_<",
+    "config.logging.showDebugMessages": "Shows debug messages in the output."
 }

--- a/server/main-beta.lua
+++ b/server/main-beta.lua
@@ -11,7 +11,6 @@ collectgarbage("setpause", 100)
 collectgarbage("setstepmul", 1000)
 
 log = require 'log'
-log.init(ROOT, ROOT / 'log' / 'service.log')
 log.info('Lua Lsp startup, root: ', ROOT)
 log.debug('ROOT:', ROOT:string())
 ac = {}

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,13 +5,10 @@ local fs = require 'bee.filesystem'
 ROOT = fs.current_path() / rootPath
 LANG = LANG or 'en-US'
 
--- output = require 'output'
---collectgarbage('generational')
 collectgarbage("setpause", 100)
 collectgarbage("setstepmul", 1000)
 
 log = require 'log'
-log.init(ROOT, ROOT / 'log' / 'service.log')
 log.info('Lua Lsp startup, root: ', ROOT)
 log.debug('ROOT:', ROOT:string())
 ac = {}

--- a/server/script/config.lua
+++ b/server/script/config.lua
@@ -90,6 +90,21 @@ local function Or(...)
     end
 end
 
+-- Just a copy and paste from the utility script.
+-- This is a fix for the early log.debug stuff at the start
+function table.deepCopy(a)
+    local t = {}
+    for k, v in pairs(a) do
+        if type(v) == 'table' then
+            t[k] = table.deepCopy(v)
+        else
+            t[k] = v
+        end
+    end
+    return t
+end
+
+
 local ConfigTemplate = {
     runtime = {
         version         = {'Luau', String},
@@ -108,7 +123,7 @@ local ConfigTemplate = {
         ignore            = {{},   Str2Hash ';'},
         disable           = {{},   Str2Hash ';'},
         severity          = {
-            table.deepCopy(DiagnosticDefaultSeverity),
+            table.deepCopy(DiagnosticDefaultSeverity) or {},
             Hash(String, String),
         },
     },
@@ -154,6 +169,9 @@ local ConfigTemplate = {
         enable          = {false, Boolean},
         path            = {'.vscode/lua-plugin/*.lua', String},
     },
+    logging = {
+        showDebugMessages = {false, Boolean}
+    }
 }
 
 local OtherTemplate = {

--- a/server/script/config.lua
+++ b/server/script/config.lua
@@ -123,7 +123,7 @@ local ConfigTemplate = {
         ignore            = {{},   Str2Hash ';'},
         disable           = {{},   Str2Hash ';'},
         severity          = {
-            table.deepCopy(DiagnosticDefaultSeverity) or {},
+            table.deepCopy(DiagnosticDefaultSeverity),
             Hash(String, String),
         },
     },

--- a/server/script/log.lua
+++ b/server/script/log.lua
@@ -74,9 +74,4 @@ function log.error(...)
     })
 end
 
-function log.init(root, path)
-    -- log.path = path:string()
-    -- log.prefix_len = #root:string()
-end
-
 return log

--- a/server/script/log.lua
+++ b/server/script/log.lua
@@ -1,4 +1,5 @@
 local rpc = require 'rpc'
+local config = require 'config'
 
 local log = {}
 
@@ -31,6 +32,7 @@ local function HandleMessageArgs(level, ...)
     -- Gather where the message came from originally.
     local ScriptInfo = debug.getinfo(3, 'Sl')
 
+    -- Combine everything into a message
     local str = '['..trim_src(ScriptInfo.source)..':'..ScriptInfo.currentline..'] '.. table.concat(t, ' ', 1, t.n)
 
     -- If the level is an error, attach the stack to the message.
@@ -50,12 +52,12 @@ function log.info(...)
 end
 
 function log.debug(...)
-    -- TODO: Add a setting to the client side to toggle if debug messages should show or not.
-
-    -- rpc:notify('window/logMessage', {
-    --     type = 4,
-    --     message = HandleMessageArgs('debug', ...)
-    -- })
+    if config.config.logging.showDebugMessages then
+        rpc:notify('window/logMessage', {
+            type = 4,
+            message = HandleMessageArgs('debug', ...)
+        })
+    end
 end
 
 function log.warn(...)

--- a/server/script/workspace.lua
+++ b/server/script/workspace.lua
@@ -144,9 +144,6 @@ function mt:init(rootUri)
     end
     log.info('Workspace inited, root: ', self.root)
     log.info('Workspace inited, uri: ', rootUri)
-    local logPath = ROOT / 'log' / (rootUri:gsub('[/:]+', '_') .. '.log')
-    log.info('Log path: ', logPath)
-    log.init(ROOT, logPath)
 end
 
 function mt:isComplete()


### PR DESCRIPTION
The current LSP logs everything in the background and will only show the output of itself when it has errored out.

This rework brings all the logging to the front end by using the LSP's `window/logMessage` feature standard. https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_logMessage

![image](https://user-images.githubusercontent.com/14226603/125367962-3c5f6500-e347-11eb-8c1d-5cfddc3225c9.png)