### PR TITLE
Allow argument name annotations in function types

### DIFF
--- a/server/script/parser/ast.lua
+++ b/server/script/parser/ast.lua
@@ -1328,6 +1328,14 @@ local Defs = {
         end
         return list
     end,
+    TypeIdTag = function(start, name, colon, finish)
+        return {
+            type = "typeIdTag",
+            name = name,
+            start = start,
+            finish = finish,
+        }
+    end,
     TypeList = function(...)
         local types = {...}
         local obj = {
@@ -1347,6 +1355,9 @@ local Defs = {
                     }
                 end
                 wantType = true
+                types[i] = nil
+            elseif v.type == "typeIdTag" then
+                -- Ignore name tags on types, they're for extra readability only
                 types[i] = nil
             else
                 if not wantType then

--- a/server/script/parser/grammar.lua
+++ b/server/script/parser/grammar.lua
@@ -401,7 +401,10 @@ Generics2   <-  Sp ({} '<' Sp (Type / Sp COMMA {})+ Sp '>' {})
 
 TypeIdTag   <-  ({} Name Sp COLON {})
             ->  TypeIdTag
-TypeList    <-  ({} PL ((TypeIdTag? Sp Type) / Sp COMMA {})* NeedPR {} Optional)
+FuncTypeList
+            <-  ({} PL ((TypeIdTag? Sp Type) / Sp COMMA {})* NeedPR {} Optional)
+            ->  TypeList
+TypeList    <-  ({} PL (Type / Sp COMMA {})* NeedPR {} Optional)
             ->  TypeList
 
 NameType    <-  Sp ({} NameBody {} Generics2? Optional)

--- a/server/script/parser/grammar.lua
+++ b/server/script/parser/grammar.lua
@@ -399,7 +399,9 @@ Generics1   <-  Sp ({} '<' Sp (Name / Sp COMMA {})+ Sp '>' {})
 Generics2   <-  Sp ({} '<' Sp (Type / Sp COMMA {})+ Sp '>' {})
             ->  Generics
 
-TypeList    <-  ({} PL (Type / Sp COMMA {})* NeedPR {} Optional)
+TypeIdTag   <-  ({} Name Sp COLON {})
+            ->  TypeIdTag
+TypeList    <-  ({} PL ((TypeIdTag? Sp Type) / Sp COMMA {})* NeedPR {} Optional)
             ->  TypeList
 
 NameType    <-  Sp ({} NameBody {} Generics2? Optional)


### PR DESCRIPTION
* Argument name annotations are allowed on function types for readability even though they don't have any semantic purpose.