### PR TITLE
Fix string.gsub type definition and table.clone indenting

### DIFF
--- a/server/def/env.luau
+++ b/server/def/env.luau
@@ -64,7 +64,7 @@ type ENV = {
 		gsub: (
 			s: string,
 			pattern: string,
-			repl: string | { [string]: string } | ((string) -> string),
+			repl: string | { [string]: string } | ((...string) -> string),
 			n: number?
 		) -> (string, number),
 		len: (s: string) -> number,
@@ -96,7 +96,7 @@ type ENV = {
 		sort: (t: table, comp: ((any, any) -> boolean)?) -> (),
 		unpack: (t: table, i: number?, j: number?) -> ...any,
 		clear: (t: table) -> (),
-                clone: (t: table) -> table,
+		clone: (t: table) -> table,
 		create: (count: number, value: any?) -> table,
 		freeze: (t: table) -> table,
 		isfrozen: (t: table) -> boolean


### PR DESCRIPTION
Changes the type definition of string.gsub to allow varargs for the replacement function in the case there are multiple capture groups, and also fixes the indenting for 	able.clone since it was done with spaces instead of tabs