### PR TITLE
Fix CFrame.Rotation

### DIFF
--- a/server/api/DataTypes.json
+++ b/server/api/DataTypes.json
@@ -1165,13 +1165,6 @@
                     "ValueType": {
                         "Name": "CFrame"
                     }
-                },
-                {
-                    "MemberType": "Property",
-                    "Name": "Rotation",
-                    "ValueType": {
-                        "Name": "CFrame"
-                    }
                 }
             ],
             "Name": "CFrame"
@@ -2662,6 +2655,13 @@
                     "Name": "Position",
                     "ValueType": {
                         "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Rotation",
+                    "ValueType": {
+                        "Name": "CFrame"
                     }
                 },
                 {


### PR DESCRIPTION
This pull request is a fix to a previous pull request: https://github.com/NightrainsRbx/RobloxLsp/pull/152

Basically, the problem is that the previous pull request put CFrame.Rotation on the global CFrame when it should only be available  from a created CFrame

Studio example:
![image](https://user-images.githubusercontent.com/68239467/171191481-dcdd0463-ecf0-4145-8b24-5824e0e2e796.png)

Roblox LSP example:
![image](https://user-images.githubusercontent.com/68239467/171191691-2232bb5d-c68f-4e30-990f-e16f2de27885.png)

note how Selene has realised the mistake yet Roblox LSP thinks it is the other way around so does not warn about it 

This change will also fix the Rotation property having no documentation
![image](https://user-images.githubusercontent.com/68239467/171192152-e1630255-f7bd-4066-be71-bc7efba56f03.png)
