### PR TITLE
Fix return type of `Color3:ToHex()`

### DIFF
--- a/server/api/DataTypes.json
+++ b/server/api/DataTypes.json
@@ -2311,17 +2311,9 @@
                     "MemberType": "Function",
                     "Name": "ToHex",
                     "Parameters": [],
-                    "TupleReturns": [
-                        {
-                            "Name": "number"
-                        },
-                        {
-                            "Name": "number"
-                        },
-                        {
-                            "Name": "number"
-                        }
-                    ]
+                    "ReturnType": {
+                        "Name": "string"
+                    }
                 },
                 {
                     "MemberType": "Function",


### PR DESCRIPTION
The return type is a string: https://create.roblox.com/docs/reference/engine/datatypes/Color3#ToHex