### PR TITLE
Remove IgnoreWater from OverlapParams

### DIFF
--- a/server/api/DataTypes.json
+++ b/server/api/DataTypes.json
@@ -3946,13 +3946,6 @@
                 },
                 {
                     "MemberType": "Property",
-                    "Name": "IgnoreWater",
-                    "ValueType": {
-                        "Name": "boolean"
-                    }
-                },
-                {
-                    "MemberType": "Property",
                     "Name": "CollisionGroup",
                     "ValueType": {
                         "Name": "string"


### PR DESCRIPTION
It is not a property of OverlapParams (as seen in https://developer.roblox.com/en-us/api-reference/datatype/OverlapParams)