### PR TITLE
Mark `vZ` in `CFrame.fromMatrix` as optional

### DIFF
--- a/server/api/DataTypes.json
+++ b/server/api/DataTypes.json
@@ -847,7 +847,8 @@
                             "Name": "vZ",
                             "Type": {
                                 "Name": "Vector3"
-                            }
+                            },
+                            "Default": "nil"
                         }
                     ],
                     "ReturnType": {


### PR DESCRIPTION
https://create.roblox.com/docs/reference/engine/datatypes/CFrame#fromMatrix mentions:
> If `vz` is excluded, the third column is calculated as `[vx:Cross(vy).Unit]`