### PR TITLE
Add ``label`` Parameter to ``PathWaypoint.new()``

### DIFF
--- a/server/api/DataTypes.json
+++ b/server/api/DataTypes.json
@@ -112,6 +112,13 @@
                                 "Category": "Enum",
                                 "Name": "PathWaypointAction"
                             }
+                        },
+                        {
+                            "Name": "label",
+                            "Default": "",
+                            "Type": {
+                                "Name": "string"
+                            }
                         }
                     ],
                     "ReturnType": {


### PR DESCRIPTION
``PathWaypoint.new()`` was missing the optional ``label`` Parameter.

API Reference:
https://create.roblox.com/docs/reference/engine/datatypes/PathWaypoint#new