### PR TITLE
Support for Argon plugin

### DIFF
--- a/server/script/library/rojo.lua
+++ b/server/script/library/rojo.lua
@@ -109,7 +109,7 @@ function rojo.searchFile(parent, filePath)
             local childName = tostring(childPath:filename())
             if rojo:scriptClass(childName) then
                 local name = removeLuaExtension(childName)
-                if name == "init" then
+                if name == "init" or name == ".source" then
                     parent.value[1] = rojo:scriptClass(childName)
                     parent.value.uri = furi.encode(childPath:string())
                     rojo.Scripts[parent.value.uri] = parent.value


### PR DESCRIPTION
Sorry for creating this PR again but I previous one got closed automatically because I removed the repo.

This change adds support for `.source` file (equivalent to `init` files), name used by my plugin [Argon](https://github.com/DervexHero/Argon) which is an alternative for Rojo.

I would really appreciate if you merge this change as doesn't affect Roblox LSP performance, but it helps me and my plugin users a lot!