### PR TITLE
Remove invalid declaration of debug.traceback()

### DIFF
--- a/server/def/env.luau
+++ b/server/def/env.luau
@@ -7,8 +7,7 @@ type ENV = {
 			((thread: thread, level: number, options: string) -> ...any)
 			& ((functionOrLevel: function | number, options: string) -> ...any),
 		traceback:
-			((level: number?) -> string)
-			& ((message: string, level: number?) -> string)
+			((message: string, level: number?) -> string)
 			& ((thread: thread, message: string, level: number?) -> string),
 		profilebegin: (label: string) -> (),
 		profileend: () -> (),


### PR DESCRIPTION
Currently, a declaration for `debug.traceback(level: number?) -> string)` exists. However, this doesn't isn't actually a real definition, if you look in studio, currently. This will just append the number before the stack trace. 