### PR TITLE
API-Dump -> Full-API-Dump

### DIFF
--- a/client/out/extension.js
+++ b/client/out/extension.js
@@ -38,7 +38,7 @@ function writeToFile(path, content) {
     }
 }
 function updateRobloxAPI(context) {
-    fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/version.txt', (lastVersion) => {
+    fetchData('https://raw.githubusercontent.com/MaximumADHD/Roblox-Client-Tracker/roblox/version.txt', (lastVersion) => {
         try {
             const currentVersion = fs.readFileSync(context.asAbsolutePath(path.join('server', 'api', 'version.txt')), 'utf8');
             if (currentVersion != lastVersion) {
@@ -49,7 +49,7 @@ function updateRobloxAPI(context) {
                 }, () => __awaiter(this, void 0, void 0, function* () {
                     return Promise.all([
                         new Promise(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/MaximumADHD/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),

--- a/client/out/extension.js
+++ b/client/out/extension.js
@@ -49,7 +49,7 @@ function updateRobloxAPI(context) {
                 }, () => __awaiter(this, void 0, void 0, function* () {
                     return Promise.all([
                         new Promise(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Full-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),

--- a/client/out/extension.js
+++ b/client/out/extension.js
@@ -49,7 +49,7 @@ function updateRobloxAPI(context) {
                 }, () => __awaiter(this, void 0, void 0, function* () {
                     return Promise.all([
                         new Promise(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Full-API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -38,7 +38,7 @@ function updateRobloxAPI(context: vscode.ExtensionContext) {
                 }, async () => {
                     return Promise.all([
                         new Promise<void>(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Full-API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -38,7 +38,7 @@ function updateRobloxAPI(context: vscode.ExtensionContext) {
                 }, async () => {
                     return Promise.all([
                         new Promise<void>(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Full-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -27,7 +27,7 @@ function writeToFile(path: string, content: string) {
 }
 
 function updateRobloxAPI(context: vscode.ExtensionContext) {
-    fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/version.txt', (lastVersion) => {
+    fetchData('https://raw.githubusercontent.com/MaximumADHD/Roblox-Client-Tracker/roblox/version.txt', (lastVersion) => {
         try {
             const currentVersion = fs.readFileSync(context.asAbsolutePath(path.join('server', 'api', 'version.txt')), 'utf8')
             if (currentVersion != lastVersion) {
@@ -38,7 +38,7 @@ function updateRobloxAPI(context: vscode.ExtensionContext) {
                 }, async () => {
                     return Promise.all([
                         new Promise<void>(resolve => {
-                            fetchData('https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
+                            fetchData('https://raw.githubusercontent.com/MaximumADHD/Roblox-Client-Tracker/roblox/Mini-API-Dump.json', (data) => {
                                 writeToFile(context.asAbsolutePath(path.join('server', 'api', 'API-Dump.json')), data);
                             }, resolve);
                         }),


### PR DESCRIPTION
Changed API-Dump link to Full-API-Dump, the structure is almost identical in both, with the exception of
Default values data being included for properties (which can be useful)

Reason: better API coverage (especially for things tagged with `NotScriptable`), without any cons.

Note: This can be optional & configurable in settings. In that case that would need extra code as this pull request is only meant to overwrite the link.

