### PR TITLE
Fix broken exported types

### DIFF
--- a/server/script/core/guide.lua
+++ b/server/script/core/guide.lua
@@ -3035,7 +3035,6 @@ function m.getTypeAlias(status, source)
                             return alias
                         end
                     end
-                    break
                 end
             end
         end

--- a/server/script/vm/getType.lua
+++ b/server/script/vm/getType.lua
@@ -45,7 +45,6 @@ function vm.getTypeAlias(source)
                             return alias
                         end
                     end
-                    break
                 end
             end
         end


### PR DESCRIPTION
There is a bug where types imported from other modules do not resolve correctly, most notably when importing multiple types in one module. This commit fixes that issue.